### PR TITLE
omb_main: umount OMB_MAIN_DIR to prevent data loss

### DIFF
--- a/src/omb_main.c
+++ b/src/omb_main.c
@@ -235,6 +235,7 @@ int main(int argc, char *argv[])
 			omb_utils_restore_kernel(item);
 			omb_utils_save(OMB_SETTINGS_SELECTED, item->identifier);
 			omb_utils_save_int(OMB_SETTINGS_FORCE, 1);
+			omb_utils_umount(OMB_MAIN_DIR);
 			omb_utils_reboot();
 			is_rebooting = 1;
 		}
@@ -242,9 +243,10 @@ int main(int argc, char *argv[])
 		if (!is_rebooting) {
 			if (item != NULL && strcmp(item->identifier, "flash") != 0)
 				omb_utils_remount_media(item);
+			omb_utils_umount(OMB_MAIN_DIR);
 			omb_utils_sysvinit(item, NULL);
 		}
-	
+
 		if (items) omb_utils_free_items(items);
 		if (selected) free(selected);
 	}


### PR DESCRIPTION
Keeping OMB_MAIN_DIR mounted can cause data loss, so we need to umount OMB_MAIN_DIR

Additionally dmesg complains about unchecked fs:
EXT3-fs (sda1): warning: mounting unchecked fs, running e2fsck is recommended
