### PR TITLE
Display image selection for images with textlcd

### DIFF
--- a/src/omb_lcd.c
+++ b/src/omb_lcd.c
@@ -69,11 +69,17 @@ int omb_lcd_read_value(const char *filename)
 int omb_lcd_open()
 {
 	omb_lcd_fd = open("/dev/dbox/lcd0", O_RDWR);
+	if (omb_lcd_fd == -1)
+		 omb_lcd_fd = open("/dev/dbox/oled0", O_RDWR);
 	if (omb_lcd_fd == -1) {
 		omb_log(LOG_ERROR, "cannot open lcd device");
 		return OMB_ERROR;
 	}
-	
+
+#ifdef OMB_HAVE_TEXTLCD
+	return OMB_SUCCESS;
+#endif
+
 	int tmp = LCD_MODE_BIN;
 	if (ioctl(omb_lcd_fd, LCD_IOCTL_ASC_MODE, &tmp)) {
 		omb_log(LOG_ERROR, "failed to set lcd bin mode");
@@ -101,7 +107,7 @@ int omb_lcd_open()
 	omb_lcd_buffer = malloc(omb_lcd_height * omb_lcd_stride);
 	
 	omb_log(LOG_DEBUG, "current lcd is %dx%d, %dbpp, stride %d", omb_lcd_width, omb_lcd_height, omb_lcd_bpp, omb_lcd_stride);
-	
+
 	return OMB_SUCCESS;
 }
 
@@ -172,4 +178,12 @@ void omb_lcd_draw_character(FT_Bitmap* bitmap, FT_Int x, FT_Int y, int color)
 			z++;
 		}
 	}
+}
+
+void omb_lcd_write_text(const char* text)
+{
+	if(omb_lcd_fd < 0)
+		return;
+
+	write(omb_lcd_fd, text, strlen(text));
 }

--- a/src/omb_lcd.h
+++ b/src/omb_lcd.h
@@ -32,5 +32,6 @@ void omb_lcd_clear();
 void omb_lcd_update();
 
 void omb_lcd_draw_character(FT_Bitmap* bitmap, FT_Int x, FT_Int y, int color);
+void omb_lcd_write_text(const char* text);
 
 #endif // _OMB_LCD_H_

--- a/src/omb_menu.c
+++ b/src/omb_menu.c
@@ -148,6 +148,9 @@ void omb_menu_render()
 		omb_device_item *item = omb_menu_get(i);
 		int color = OMB_MENU_ITEM_COLOR;
 		if (i == omb_menu_selected) {
+#ifdef OMB_HAVE_TEXTLCD
+			omb_lcd_write_text(item->label);
+#else
 			int selection_y = omb_lcd_get_height() * OMB_LCD_SELECTION_Y;
 			int selection_size = omb_lcd_get_width() * OMB_LCD_SELECTION_SIZE;
 			
@@ -158,6 +161,7 @@ void omb_menu_render()
 				OMB_LCD_SELECTION_COLOR,
 				selection_size,
 				OMB_TEXT_ALIGN_CENTER);
+#endif
 			
 			color = OMB_MENU_ITEM_SELECTED_COLOR;
 		}


### PR DESCRIPTION
When image has MACHINE_FEATURES textlcd it should write text
to lcd device. Also check if /dev/dbox/oled0 device exist.

In order to use it we need the following into EXTRA_OEMAKE
${@base_contains("MACHINE_FEATURES", "textlcd", "-DOMB_HAVE_TEXTLCD" , "", d)}
