### PR TITLE
Run volatile media before mdev

### DIFF
--- a/src/omb_common.h
+++ b/src/omb_common.h
@@ -48,6 +48,7 @@
 #define OMB_DEFAULT_TIMER 5
 #endif
 #define OMB_SHOWIFRAME_BIN "/usr/bin/showiframe"
+#define OMB_VOLATILE_MEDIA_BIN "/etc/init.d/volatile-media.sh"
 #define OMB_MDEV_BIN "/etc/init.d/mdev"
 #define OMB_MODUTILS_BIN "/etc/init.d/modutils.sh"
 #define OMB_INIT_BIN "/sbin/init"

--- a/src/omb_utils.c
+++ b/src/omb_utils.c
@@ -300,7 +300,10 @@ void omb_utils_init_system()
 	if (!omb_utils_is_mounted("/media"))
 		if (mount("tmpfs", "/media", "tmpfs", 0, "size=64k") != 0)
 			omb_log(LOG_ERROR, "cannot mount /media");
-	
+
+	omb_log(LOG_DEBUG, "run volatile media");
+	system(OMB_VOLATILE_MEDIA_BIN);
+
 	omb_log(LOG_DEBUG, "run mdev");
 	system(OMB_MDEV_BIN);
 	


### PR DESCRIPTION
Without volatile media mountpoints under media are not populated,
so mounts defined on fstab are failing to mount by mdev at fstab
location. Later at boot volatile media run again followed by mdev
and now mount fstab succeds, so you have same device mounted twice

Running volatile media before mdev fixes above issue.
